### PR TITLE
Fix: Add missing header for uin64_t.

### DIFF
--- a/src/engine/common/index_vector.hpp
+++ b/src/engine/common/index_vector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstdint>
 
 
 namespace civ


### PR DESCRIPTION
This PR fixes issue #5.

It seems that with newer GCC version the header structure changed and thus one header was missing.
It was tested on Fedora 38 and Ubuntu 22.04.